### PR TITLE
Add autocomplete for landlord and unit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,16 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+# Basic authorization
 gem 'cancancan'
+
+# Provides more detailed date validations; successions
 gem 'date_validator'
+
+# Authentication
 gem 'devise'
+
+# Enables font-awesome icons
 gem 'font-awesome-sass'
 
 group :development, :test do

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
  *= require_self
  */
 
+@import 'easy-autocomplete/dist/easy-autocomplete';
 @import "font-awesome-sprockets";
 @import "font-awesome";
 

--- a/app/controllers/landlords_controller.rb
+++ b/app/controllers/landlords_controller.rb
@@ -11,4 +11,14 @@ class LandlordsController < ApplicationController
     @title = @landlord.name
     @units = @landlord.units
   end
+
+  # GET /landlords/search.json
+  def search
+    q = params[:q].downcase
+    @landlords = Landlord.where("name ILIKE ?", "%#{q}%").limit(6)
+
+    response do
+      format.json { @landlords.json }
+    end
+  end
 end

--- a/app/controllers/union/tenancies_controller.rb
+++ b/app/controllers/union/tenancies_controller.rb
@@ -67,11 +67,6 @@ class Union::TenanciesController < Union::BaseController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    #def set_Tenancy
-    #  @tenancy = Tenancy.find(params[:id])
-    #end
-
     def setup_form_data
       @units = Unit.all
       @landlords = Landlord.all
@@ -79,6 +74,8 @@ class Union::TenanciesController < Union::BaseController
 
     # Only allow a list of trusted parameters through.
     def tenancy_params
-      params.require(:tenancy).permit(:landlord_id, :unit_id, :rent_total, :rent_portion, :start_date, :end_date, :overall, :repairs, :public_review, :private_review)
+      params[:tenancy][:unit_id] = Unit.find_or_create_by(address: params[:tenancy].delete(:unit_address)).to_param
+      params[:tenancy][:landlord_id] = Landlord.find_or_create_by(name: params[:tenancy].delete(:landlord_name)).to_param
+      params.require(:tenancy).permit(:landlord_id, :landlord_name, :unit_address, :unit_id, :rent_total, :rent_portion, :start_date, :end_date, :overall, :repairs, :public_review, :private_review)
     end
 end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -10,4 +10,14 @@ class UnitsController < ApplicationController
     @unit = Unit.includes(:tenancies, tenancies: [:landlord, :tenant]).find(params[:id])
     @title = @unit&.address || "Not found"
   end
+
+  # GET /landlords/search.json
+  def search
+    q = params[:q].downcase
+    @units = Unit.where("address ILIKE ?", "%#{q}%").limit(6)
+
+    response do
+      format.json { @units.json }
+    end
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,10 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-
+require("jquery")
+require("easy-autocomplete")
+require('packs/autocomplete')
+require('packs/flash_hash')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -16,11 +19,4 @@ require("channels")
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-import "stylesheets/application"
-
-
-$(document).ready(function() { 
-  $('.flash a.close').on('click', function(e) {
-    $(e.target).closest('.flash').fadeOut(500, function() { $(this).remove(); });
-  });
-});
+// import "stylesheets/application"

--- a/app/javascript/packs/autocomplete.js
+++ b/app/javascript/packs/autocomplete.js
@@ -2,7 +2,7 @@
 
 $(document).on('turbolinks:load', function() {
 
-  var options = {
+  var landlord_options = {
     url: function(phrase) {
       return "/landlords/search.json?q=" + phrase;
     },
@@ -22,6 +22,27 @@ $(document).on('turbolinks:load', function() {
     },
   };
 
-  $('*[data-behavior="autocomplete"]').easyAutocomplete(options);
+  var unit_options = {
+    url: function(address) {
+      return "/units/search.json?q=" + address;
+    },
+    getValue: "address",
+    list: {
+      onClickEvent: function() {
+        var selectedItemValue = $('#unit_autocomplete').getSelectedItemData().unit_id;
+        $("#tenancy_unit_id").val(selectedItemValue).trigger("change");
+      },
+      onKeyEnterEvent: function() {
+        var selectedItemValue = $('#unit_autocomplete').getSelectedItemData().unit_id;
+        $("#tenancy_unit_id").val(selectedItemValue).trigger("change");
+      },
+      match: {
+        enabled: true
+      }
+    },
+  };
+
+  $('#landlord_autocomplete[data-behavior="autocomplete"]').easyAutocomplete(landlord_options);
+  $('#unit_autocomplete[data-behavior="autocomplete"]').easyAutocomplete(unit_options);
 });
 

--- a/app/javascript/packs/autocomplete.js
+++ b/app/javascript/packs/autocomplete.js
@@ -7,15 +7,8 @@ $(document).on('turbolinks:load', function() {
       return "/landlords/search.json?q=" + phrase;
     },
     getValue: "name",
+    requestDelay: 400,
     list: {
-      onClickEvent: function() {
-        var selectedItemValue = $('#landlord_autocomplete').getSelectedItemData().landlord_id;
-        $("#tenancy_landlord_id").val(selectedItemValue).trigger("change");
-      },
-      onKeyEnterEvent: function() {
-        var selectedItemValue = $('#landlord_autocomplete').getSelectedItemData().landlord_id;
-        $("#tenancy_landlord_id").val(selectedItemValue).trigger("change");
-      },
       match: {
         enabled: true
       }
@@ -27,15 +20,8 @@ $(document).on('turbolinks:load', function() {
       return "/units/search.json?q=" + address;
     },
     getValue: "address",
+    requestDelay: 400,
     list: {
-      onClickEvent: function() {
-        var selectedItemValue = $('#unit_autocomplete').getSelectedItemData().unit_id;
-        $("#tenancy_unit_id").val(selectedItemValue).trigger("change");
-      },
-      onKeyEnterEvent: function() {
-        var selectedItemValue = $('#unit_autocomplete').getSelectedItemData().unit_id;
-        $("#tenancy_unit_id").val(selectedItemValue).trigger("change");
-      },
       match: {
         enabled: true
       }

--- a/app/javascript/packs/autocomplete.js
+++ b/app/javascript/packs/autocomplete.js
@@ -1,0 +1,27 @@
+// http://easyautocomplete.com/guide
+
+$(document).on('turbolinks:load', function() {
+
+  var options = {
+    url: function(phrase) {
+      return "/landlords/search.json?q=" + phrase;
+    },
+    getValue: "name",
+    list: {
+      onClickEvent: function() {
+        var selectedItemValue = $('#landlord_autocomplete').getSelectedItemData().landlord_id;
+        $("#tenancy_landlord_id").val(selectedItemValue).trigger("change");
+      },
+      onKeyEnterEvent: function() {
+        var selectedItemValue = $('#landlord_autocomplete').getSelectedItemData().landlord_id;
+        $("#tenancy_landlord_id").val(selectedItemValue).trigger("change");
+      },
+      match: {
+        enabled: true
+      }
+    },
+  };
+
+  $('*[data-behavior="autocomplete"]').easyAutocomplete(options);
+});
+

--- a/app/javascript/packs/flash_hash.js
+++ b/app/javascript/packs/flash_hash.js
@@ -1,0 +1,5 @@
+$(document).on('turbolinks:load', function() { 
+  $('.flash a.close').on('click', function(e) {
+    $(e.target).closest('.flash').fadeOut(500, function() { $(this).remove(); });
+  });
+});

--- a/app/models/tenancy.rb
+++ b/app/models/tenancy.rb
@@ -33,4 +33,12 @@ class Tenancy < ApplicationRecord
   scope :by_unit, ->(unit) { where(unit: unit) }
   scope :by_tenant, ->(user) { where(users: { id: user.id }) }
   scope :by_landlord, ->(landlord) { where(landlord: landlord )}
+
+  def landlord_name
+    landlord.name
+  end
+
+  def unit_address
+    unit.address
+  end
 end

--- a/app/views/landlords/search.json.jbuilder
+++ b/app/views/landlords/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@landlords) do |landlord|
+  json.name landlord.name
+  json.landlord_id landlord.id
+end

--- a/app/views/shared/_edit_button.html.erb
+++ b/app/views/shared/_edit_button.html.erb
@@ -1,4 +1,4 @@
-<%= link_to target do %>
+<%= link_to target, class: "ui yellow button" do %>
   <%= icon('fas', 'pencil') %>
   Edit
 <% end %>

--- a/app/views/shared/_new_button.html.erb
+++ b/app/views/shared/_new_button.html.erb
@@ -1,4 +1,4 @@
-<%= link_to target do %>
+<%= link_to target, class: "ui blue button" do %>
   <%= icon('fas', 'plus') %>
   New
 <% end %>

--- a/app/views/union/tenancies/_form.html.erb
+++ b/app/views/union/tenancies/_form.html.erb
@@ -12,10 +12,9 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :unit_id do %>
-      <span>Unit</span>
-      <%= form.collection_select :unit_id, @units, :id, :address, {}, { } %>
-    <% end %>
+    <%= form.label :unit_id, "Address" %>
+    <%= form.search_field :unit_Address, placeholder: "Street Address...", id: "unit_autocomplete", data: { behavior: "autocomplete" } %>    
+    <%= form.hidden_field :unit_id %>
   </div>
 
   <div class="field">

--- a/app/views/union/tenancies/_form.html.erb
+++ b/app/views/union/tenancies/_form.html.erb
@@ -11,70 +11,65 @@
     </div>
   <% end %>
 
-  <div>
+  <div class="field">
     <%= form.label :unit_id do %>
       <span>Unit</span>
       <%= form.collection_select :unit_id, @units, :id, :address, {}, { } %>
     <% end %>
   </div>
 
-  <div>
-    <div>
-        <%= form.label :rent_portion do %>
-          <span>The portion of rent you pay</span>
-          <%= form.text_field :rent_portion %>
+  <div class="field">
+    <div class="two fields">
+      <div class="field">
+          <%= form.label :rent_portion do %>
+            <span>The portion of rent you pay</span>
+            <%= form.text_field :rent_portion %>
+          <% end %>
+      </div>
+
+      <div class="field">
+        <%= form.label :rent_total do %>
+          <span>The total monthly rent</span>
+          <%= form.text_field :rent_total %>
         <% end %>
-    </div>
-
-    <div>
-      <%= form.label :rent_total do %>
-        <span>The total monthly rent</span>
-        <%= form.text_field :rent_total %>
-      <% end %>
+      </div>
     </div>
   </div>
-  
 
-  <div>
-    <%= form.label :landlord_id do %>
-    <span>Landlord</span>
-      <%= form.collection_select :landlord_id, @landlords, :id, :name, {}, { } %>
-    <% end %>
+  <div class="field">
+    <%= form.label :landlord_id, "Landlord" %>
+    <%= form.search_field :landlord_name, placeholder: "Enter name...", id: "landlord_autocomplete", data: { behavior: "autocomplete" } %>    
+    <%= form.hidden_field :landlord_id %>
   </div>
 
-  <div>
-    <div>
-      <%= form.label :start_date do %>
-        <span>Start Date</span>
-        <%= form.date_field :start_date %>
-      <% end %>
-    </div>
+  <div class="field">
+    <div class="two fields">
+      <div class="field">
+        <%= form.label :start_date do %>
+          <span>Start Date</span>
+          <%= form.date_field :start_date %>
+        <% end %>
+      </div>
 
-      <div>
+      <div class="field">
         <%= form.label :end_date do %>
           <span>End Date</span>
           <%= form.date_field :end_date, include_blank: true %>
         <% end %>
       </div>
     </div>
+  </div>
 
-    <div>
-      <div>
-      <%= form.label :overall do %>
-        <span>Overall Rating</span>
-        <div>
-          <%= form.collection_radio_buttons :overall, [['0', icon('fas', "angry", 'Awful')] ,['1', icon('fas', "frown", 'Poor')], ['2', icon('fas', 'meh', 'OK')], ['3', icon('fas', "smile", "Good")]], :first, :last %>
-        </div>
-      <% end %>
-    </div>
+    <div class="field">
+      <div class="two fields">
+      <div class="field rating">
+        <%= form.label :overall, "Overall Rating" %>
+        <%= form.collection_radio_buttons :overall, [['0', icon('fas', "angry", 'Awful')] ,['1', icon('fas', "frown", 'Poor')], ['2', icon('fas', 'meh', 'OK')], ['3', icon('fas', "smile", "Good")]], :first, :last %>
+      </div>
 
-      <div>
-        <%= form.label :repairs do %>
-          <span>Repairs Rating</span>
-          <div>
-            <%= form.collection_radio_buttons :repairs, [['0', icon('fas', "angry", 'Awful')] ,['1', icon('fas', "frown", 'Poor')], ['2', icon('fas', 'meh', 'OK')], ['3', icon('fas', "smile", "Good")], ['', icon('fas', 'comment-slash', 'N/A')]], :first, :last %>
-          </div>
-        <% end %>
+      <div class="field rating">
+        <%= form.label :repairs, "Repairs Rating" %>
+        <%= form.collection_radio_buttons :repairs, [['0', icon('fas', "angry", 'Awful')] ,['1', icon('fas', "frown", 'Poor')], ['2', icon('fas', 'meh', 'OK')], ['3', icon('fas', "smile", "Good")], ['', icon('fas', 'comment-slash', 'N/A')]], :first, :last %>
       </div>
     </div>
 

--- a/app/views/union/tenancies/_form.html.erb
+++ b/app/views/union/tenancies/_form.html.erb
@@ -13,8 +13,7 @@
 
   <div class="field">
     <%= form.label :unit_id, "Address" %>
-    <%= form.search_field :unit_Address, placeholder: "Street Address...", id: "unit_autocomplete", data: { behavior: "autocomplete" } %>    
-    <%= form.hidden_field :unit_id %>
+    <%= form.search_field :unit_address, placeholder: "Street Address...", id: "unit_autocomplete", data: { behavior: "autocomplete" } %>    
   </div>
 
   <div class="field">
@@ -38,7 +37,6 @@
   <div class="field">
     <%= form.label :landlord_id, "Landlord" %>
     <%= form.search_field :landlord_name, placeholder: "Enter name...", id: "landlord_autocomplete", data: { behavior: "autocomplete" } %>    
-    <%= form.hidden_field :landlord_id %>
   </div>
 
   <div class="field">
@@ -87,6 +85,6 @@
   </div>
 
   <div>
-    <%= form.submit %>
+    <%= form.submit "Save", class: "ui button green" %>
   </div>
 <% end %>

--- a/app/views/units/search.json.jbuilder
+++ b/app/views/units/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.array!(@units) do |unit|
+  json.address unit.address
+  json.unit_id unit.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,10 @@ Rails.application.routes.draw do
   get 'ratings', to: 'tenancies#index', as: :ratings
   get 'ratings/:id', to: 'tenancies#show', as: :rating
   
-  resources :units, only: %i(index show)
+  resources :units, only: %i(index show) do
+    get :search, on: :collection
+  end
+  
   resources :landlords, only: %i(index show) do
     get :search, on: :collection
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,9 @@ Rails.application.routes.draw do
   get 'ratings', to: 'tenancies#index', as: :ratings
   get 'ratings/:id', to: 'tenancies#show', as: :rating
   
-  resources :units, only: %i(index show) do
-    resources :ratings, only: %i(index show)
-  end
+  resources :units, only: %i(index show)
   resources :landlords, only: %i(index show) do
-    resources :ratings, only: %i(index show)
+    get :search, on: :collection
   end
   
   put 'profile', to: 'profiles#update'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -4,8 +4,9 @@ module.exports = environment
 
 const webpack = require("webpack")
 
-environment.plugins.append("Provide", new webpack.ProvidePlugin({
-  $: 'jquery',
-  jQuery: 'jquery',
-  Popper: ['popper.js', 'default']
-}))
+environment.plugins.append("Provide",
+  new webpack.ProvidePlugin({
+    $: 'jquery/src/jquery',
+    jQuery: 'jquery/src/jquery'
+  })
+)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.3.0",
     "autoprefixer": "^9",
+    "easy-autocomplete": "^1.3.5",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "postcss": "^7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2613,6 +2613,13 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+easy-autocomplete@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/easy-autocomplete/-/easy-autocomplete-1.3.5.tgz#2a2d2df699f13ddc48661c9375b9437acf1a0a9c"
+  integrity sha1-Ki0t9pnxPdxIZhyTdblDes8aCpw=
+  dependencies:
+    jquery "*"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
@@ -4017,7 +4024,7 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.5.1:
+jquery@*, jquery@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==


### PR DESCRIPTION
# Overview
Closes #6 

 - Uses the [EasyAutocomplete](http://easyautocomplete.com/) node package
 - Unit and Landlord fields on the Tenancy form are wired up with it. Can be rolled out elsewhere pretty easily
 - Search routes are on public side so we can reuse them later
 - strong params in `Union::TenanciesController` do a quick lookup for both `Unit` and `Landlord` (see below)
 - 400ms delay before retrieval to reduce lookup roundtrips

Overall, this PR is pretty solid. The compromises to standard Rails Way approaches feel minimal and consistently reproducible.

# Strong Params changes
```ruby
    # Only allow a list of trusted parameters through.
    def tenancy_params
      params[:tenancy][:unit_id] = Unit.find_or_create_by(address: params[:tenancy].delete(:unit_address)).to_param
      params[:tenancy][:landlord_id] = Landlord.find_or_create_by(name: params[:tenancy].delete(:landlord_name)).to_param
      params.require(:tenancy).permit(:landlord_id, :landlord_name, :unit_address, :unit_id, :rent_total, :rent_portion, :start_date, :end_date, :overall, :repairs, :public_review, :private_review)
    end
```
The form uses phantom data -- it works based off of the unit and address. Since creation can only be done by tenants, internally, we're a little more liberal with how these records can be created. The unit and landlord are `find_or_created` first and then the params hash has the `id` for those records added to it, all before the `Tenancy` resource is dealt with.

This small bit of offroading here allows for a more direct interaction with the UI side. The alternative would be to grab the ID on the API call (not a problem!), persist it to a hidden field, then have the hidden field do the lookup, if that fails, then look for the string parameter and create the new record from it. I tried it like that initially and this felt easier, and was a small enough deviation it felt justified. It also allowed for less JS. :D

# Model helper methods
The unit / landlord values are displayable in the search fields because I added helper methods to the model for `:landlord_name` and `:unit_address` which access those respective fields. The methods incorporate no business logic, but do allow Rails Magic to display the field data more seamlessly.

