### PR TITLE
Gently forces the autocomplete fields to default values

### DIFF
--- a/app/controllers/union/tenancies_controller.rb
+++ b/app/controllers/union/tenancies_controller.rb
@@ -1,7 +1,6 @@
 class Union::TenanciesController < Union::BaseController
-  load_and_authorize_resource
+  load_and_authorize_resource only: [:show, :index, :destroy]
 
-  before_action :setup_form_data, only: %i[new edit]
   before_action :authenticate_user!, only: %i[new edit update destroy]
 
   # GET /tenancies or /tenancies.json
@@ -25,6 +24,8 @@ class Union::TenanciesController < Union::BaseController
   # GET /tenancies/1/edit
   def edit
     @title = "Editing Tenancy"
+    @tenancy = Tenancy.find(params[:id])
+    authorize! :edit, @tenancy
   end
 
   # POST /tenancies or /tenancies.json
@@ -36,7 +37,6 @@ class Union::TenanciesController < Union::BaseController
         format.html { redirect_to [:union, @tenancy], notice: "Tenancy was successfully created." }
         format.json { render :show, status: :created, location: @tenancy }
       else
-        setup_form_data
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @tenancy.errors, status: :unprocessable_entity }
       end
@@ -45,12 +45,13 @@ class Union::TenanciesController < Union::BaseController
 
   # PATCH/PUT /Tenancies/1 or /Tenancies/1.json
   def update
+    @tenancy = Tenancy.find(params[:id])
+    authorize! :update, @tenancy
     respond_to do |format|
       if @tenancy.update(tenancy_params)
         format.html { redirect_to [:union, @tenancy], notice: "Tenancy was successfully updated." }
         format.json { render :show, status: :ok, location: @tenancy }
       else
-        setup_form_data
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @tenancy.errors, status: :unprocessable_entity }
       end
@@ -67,11 +68,6 @@ class Union::TenanciesController < Union::BaseController
   end
 
   private
-    def setup_form_data
-      @units = Unit.all
-      @landlords = Landlord.all
-    end
-
     # Only allow a list of trusted parameters through.
     def tenancy_params
       params[:tenancy][:unit_id] = Unit.find_or_create_by(address: params[:tenancy].delete(:unit_address)).to_param

--- a/app/views/union/tenancies/_form.html.erb
+++ b/app/views/union/tenancies/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="field">
     <%= form.label :unit_id, "Address" %>
-    <%= form.search_field :unit_address, placeholder: "Street Address...", id: "unit_autocomplete", data: { behavior: "autocomplete" } %>    
+    <%= form.search_field :unit_address, placeholder: "Street Address...", value: form.object.unit_address, id: "unit_autocomplete", data: { behavior: "autocomplete" } %>    
   </div>
 
   <div class="field">
@@ -36,7 +36,7 @@
 
   <div class="field">
     <%= form.label :landlord_id, "Landlord" %>
-    <%= form.search_field :landlord_name, placeholder: "Enter name...", id: "landlord_autocomplete", data: { behavior: "autocomplete" } %>    
+    <%= form.search_field :landlord_name, placeholder: "Enter name...", value: form.object.landlord_name, id: "landlord_autocomplete", data: { behavior: "autocomplete" } %>    
   </div>
 
   <div class="field">


### PR DESCRIPTION
Fixes #25

Cancancan load_and_authorize_resource was trying to do the create/update
business automatically. It's disabled for those actions and manually
authorized in the actions instead.

The fields were not getting their default values set correctly, so I
changed the value to directly point to the model's virtual attributes
that have graceful degradation.