### PR TITLE
nil ratings no longer report as F

### DIFF
--- a/app/helpers/ratings_helper.rb
+++ b/app/helpers/ratings_helper.rb
@@ -25,6 +25,7 @@ module RatingsHelper
   end
 
   def clamp_rating(value)
+    return nil unless value
     case value.to_f
     when 0...1
       "F"

--- a/app/models/concerns/average_ratings.rb
+++ b/app/models/concerns/average_ratings.rb
@@ -1,9 +1,13 @@
 module AverageRatings
   def overall_average
+    return nil if size.zero?
     average(:overall).to_f
   end
 
   def repairs_average
-    average(:repairs).to_f
+    ratings = self.where.not(repairs: nil)
+    return nil if ratings.empty?
+    
+    ratings.average(:repairs).to_f
   end
 end

--- a/app/views/tenancies/_rating_card.html.erb
+++ b/app/views/tenancies/_rating_card.html.erb
@@ -1,5 +1,7 @@
-<% grade = rating_grade(rating_card.send(score), nil) 
-   colors = { "A" => "blue", "B" => "green", "C" => "yellow", "D" => "orange", "F" => "red" }
+<% 
+  rating_score = rating_card.send(score)
+  grade = rating_grade(rating_score, nil) 
+  colors = { "A" => "blue", "B" => "green", "C" => "yellow", "D" => "orange", "F" => "red" }
 %>
 
 
@@ -9,10 +11,14 @@
   </div>
   <div class="content">
     <a class="ui massive circular label <%= colors[grade] %>">
-      <%= rating_grade(rating_card.send(score), nil) %>
+      <%= rating_grade(rating_score, nil) %>
     </a>
     <p class="ui floated right">
-    <%= rating_card.send(score).round(2) %> / 3.0  (<%= rating_card.size %> reviews)
+      <% if rating_score %>
+        <%= rating_score.round(2) %> / 3.0  (<%= rating_card.size %> reviews)
+      <% else %>
+        No reviews yet!
+      <% end %>
   </p>
   </div>
 

--- a/app/views/units/_unit_card.html.erb
+++ b/app/views/units/_unit_card.html.erb
@@ -4,10 +4,10 @@
   </div>
   <div class="content">
     <p>
-      Average Rating <%= rating_grade(@landlord.ratings.overall_average) %>
+      Average Rating <%= rating_grade(unit_card.ratings.overall_average) %>
     </p>
     <p>
-      Reviewed <%= @landlord.ratings.size %> times
+      Reviewed <%= unit_card.ratings.size %> times
     </p>
   </div>
   <div class="extra content">

--- a/spec/support/rating_shared_example.rb
+++ b/spec/support/rating_shared_example.rb
@@ -26,6 +26,14 @@ RSpec.shared_examples "average_ratings" do |which|
 
         expect(subject.ratings.repairs_average.round(3)).to eq((5/3.0).round(3))
       end
+
+      it "returns nil when all the ratings are nil" do
+        [nil,nil,nil,nil,nil].each do |score|
+          create(:tenancy, :with_rating, which => subject, repairs: score)
+        end
+
+        expect(subject.ratings.repairs_average).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #15

Previously, when ratings were missing, it would be reported as an F/0
With the repair averages, there was a calculation issue where if there
were no entries, or all the entries were nil, it would also report as
F/0. This commit adds some guard clauses and pre-checks to ensure that
the value is calculated accurately.