### PR TITLE
Creates new /admin namespace for Administration

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,9 @@
+class Admin::BaseController < ApplicationController 
+  before_action :authenticate_user!, :admins_only!
+
+
+protected
+  def admins_only!
+    raise CanCan::AccessDenied unless current_user.admin?
+  end
+end

--- a/app/controllers/admin/tenancies_controller.rb
+++ b/app/controllers/admin/tenancies_controller.rb
@@ -1,0 +1,6 @@
+class Admin::TenanciesController < Admin::BaseController
+  load_and_authorize_resource
+
+  def index
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
       format.json { head :forbidden, content_type: 'text/html' }
-      format.html { redirect_to main_app.root_url, notice: exception.message }
+      format.html { redirect_to main_app.new_user_session_url, notice: exception.message }
       format.js   { head :forbidden, content_type: 'text/html' }
     end
   end

--- a/app/controllers/union/tenancies_controller.rb
+++ b/app/controllers/union/tenancies_controller.rb
@@ -1,7 +1,7 @@
 class Union::TenanciesController < Union::BaseController
   load_and_authorize_resource only: [:show, :index, :destroy]
 
-  before_action :authenticate_user!, only: %i[new edit update destroy]
+  before_action :authenticate_user!#, only: %i[new edit update destroy]
 
   # GET /tenancies or /tenancies.json
   def index

--- a/app/views/admin/tenancies/index.html.erb
+++ b/app/views/admin/tenancies/index.html.erb
@@ -1,0 +1,17 @@
+<table>
+  <thead>
+    <tr>
+      <th>User</th>
+      <th>Landlord Name</th>
+      <th>Unit Address</th>
+      <th>Overall Rating</th>
+      <th>Repairs Rating</th>
+      <th>Public Review</th>
+      <th>Private Review</th>
+      <th></th>
+    </tr>
+  </thead>
+
+  <tbody>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :tenancies, only: %i(index)
+  end
+
   namespace :union do
     resources :landlords
     resources :units

--- a/spec/requests/admin/tenancies_spec.rb
+++ b/spec/requests/admin/tenancies_spec.rb
@@ -1,0 +1,42 @@
+ require 'rails_helper'
+
+RSpec.describe "/union/tenancies", type: :request do
+  let(:tenant) { create(:user, :tenant) }
+  let(:admin) { create(:user, :admin) }
+  let(:landlord) { create(:landlord) }
+
+  context "While not signed in" do
+    describe "GET #index" do
+      it "redirects to the root with forbidden" do
+        get admin_tenancies_url
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  context "While signed in as a tenant" do
+    before do
+      sign_in(tenant)
+    end
+
+    describe "GET #index" do
+      it "redirects to the root with forbidden" do
+        get admin_tenancies_url
+        expect(response).to redirect_to new_user_session_url
+      end
+    end
+  end
+
+  context "While signed in as an admin" do
+    before do
+      sign_in admin
+    end
+
+    describe "GET #index" do
+      it "redirects to the root with forbidden" do
+        get admin_tenancies_url
+        expect(response).to be_successful
+      end
+    end
+  end  
+end

--- a/spec/requests/union/landlords_spec.rb
+++ b/spec/requests/union/landlords_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "/union/landlords", type: :request do
 
         it "does nothing, no access" do
           patch union_landlord_url(landlord), params: { landlord: new_attributes }
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to new_user_session_url
         end
       end
     end

--- a/spec/requests/union/units_spec.rb
+++ b/spec/requests/union/units_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "/units", type: :request do
 
       it "does nothing, no access" do
         patch union_unit_url(unit), params: { unit: new_attributes }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to new_user_session_url
       end
     end
 


### PR DESCRIPTION
Fixes #31

Creates a new admin namespace and a basic
controller for Tenancies. Modifies existing
behavior for AccessDenied to redirect to sign-in
instead of root